### PR TITLE
MQTT: Device discovery for Home Assistant

### DIFF
--- a/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT/LoRa_Gateway_MQTT.ino
+++ b/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT/LoRa_Gateway_MQTT.ino
@@ -6,7 +6,6 @@
 #include "SSD1306Wire.h"
 SSD1306Wire display(OLED_ADDRESS, OLED_SDA, OLED_SCL);
 
-
 ///////////////////////////////////////////////////// CHANGE THIS /////////////////////////////////////////////////////////////
 
 #define SignalBandwidth 125E3
@@ -17,22 +16,18 @@ SSD1306Wire display(OLED_ADDRESS, OLED_SDA, OLED_SCL);
 #define TxPower 20
 float BAND = 868E6; // 433E6 / 868E6 / 915E6 /
 
-
-
-const char* ssid = "Your_WIFI_SSID";
-const char* password = "Your_WIFI_password";
-const char* mqtt_username = "Your_mqtt_username";
-const char* mqtt_password = "Your_mqtt_password";
-const char* mqtt_server = "Your_mqtt/homeassistant server IP";
+const char *ssid = "Your_WIFI_SSID";
+const char *password = "Your_WIFI_password";
+const char *mqtt_username = "Your_mqtt_username";
+const char *mqtt_password = "Your_mqtt_password";
+const char *mqtt_server = "Your_mqtt/homeassistant server IP";
 const int mqtt_port = 1883;
 bool retain = true;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
 String recv;
 int count = 0;
-
 
 WiFiClient espClient;
 PubSubClient client(espClient);
@@ -48,43 +43,33 @@ void setup_wifi() {
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");
-    
   }
 
   Serial.println("");
   Serial.println("WiFi connected");
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
-
-  
 }
-
-
-
 
 void reconnect() {
   while (!client.connected()) {
     Serial.print("Attempting MQTT connection...");
- 
+
     // Create a random client ID
     String clientId = "LoRaGateway-";
     clientId += String(random(0xffff), HEX);
 
     // Attempt to connect
     if (client.connect(clientId.c_str(), mqtt_username, mqtt_password)) {
-        Serial.println("MQTT connected");
-      }
-    else
-      {
-        Serial.print("MQTT failed, rc=");
-        Serial.print(client.state());
-        Serial.println(" try again in 1 seconds");
-        delay(1000);
+      Serial.println("MQTT connected");
+    } else {
+      Serial.print("MQTT failed, rc=");
+      Serial.print(client.state());
+      Serial.println(" try again in 1 seconds");
+      delay(1000);
     }
   }
 }
-
-
 
 void setup() {
   Serial.begin(9600);
@@ -93,71 +78,58 @@ void setup() {
   setup_wifi();
   client.setServer(mqtt_server, mqtt_port);
   reconnect();
-  //client.setCallback(MQTTCallback);
-  
+  // client.setCallback(MQTTCallback);
+
   display.init();
-  
-      display.flipScreenVertically();
-      display.setFont(ArialMT_Plain_10);
-      display.setTextAlignment(TEXT_ALIGN_CENTER);
-      display.drawString(64, 5, "PricelessToolkit");
-      display.setFont(ArialMT_Plain_16);
-      display.setTextAlignment(TEXT_ALIGN_CENTER);
-      display.drawString(64, 20, "LoRa Gateway");
-      display.drawString(64, 38, "RX " + String(BAND));
-      display.display();
-      delay(2000);
-      display.clear();
-      display.display();
-   
 
-
-
+  display.flipScreenVertically();
+  display.setFont(ArialMT_Plain_10);
+  display.setTextAlignment(TEXT_ALIGN_CENTER);
+  display.drawString(64, 5, "PricelessToolkit");
+  display.setFont(ArialMT_Plain_16);
+  display.setTextAlignment(TEXT_ALIGN_CENTER);
+  display.drawString(64, 20, "LoRa Gateway");
+  display.drawString(64, 38, "RX " + String(BAND));
+  display.display();
+  delay(2000);
+  display.clear();
+  display.display();
 
   SPI.begin(CONFIG_CLK, CONFIG_MISO, CONFIG_MOSI, CONFIG_NSS);
   LoRa.setPins(CONFIG_NSS, CONFIG_RST, CONFIG_DIO0);
-  Serial.println("Starting LoRa on " + String(BAND)+ " MHz");
+  Serial.println("Starting LoRa on " + String(BAND) + " MHz");
   if (!LoRa.begin(BAND)) {
-      Serial.println("Starting LoRa failed!");
-      while (1);
+    Serial.println("Starting LoRa failed!");
+    while (1);
   }
-  
-  LoRa.setSignalBandwidth(SignalBandwidth);         // signal bandwidth in Hz, defaults to 125E3
-  LoRa.setSpreadingFactor(SpreadingFactor);                 // ranges from 6-12,default 7 see API docs
-  LoRa.setCodingRate4(CodingRate);        // Supported values are between 5 and 8, these correspond to coding rates of 4/5 and 4/8. The coding rate numerator is fixed at 4.
-  LoRa.setSyncWord(SyncWord);                     // byte value to use as the sync word, defaults to 0x12
-  LoRa.setPreambleLength(PreambleLength);       //Supported values are between 6 and 65535.
-  LoRa.disableCrc();                          // Enable or disable CRC usage, by default a CRC is not used LoRa.disableCrc();
-  LoRa.setTxPower(TxPower);                // TX power in dB, defaults to 17, Supported values are 2 to 20
-  
+
+  LoRa.setSignalBandwidth(SignalBandwidth); // signal bandwidth in Hz, defaults to 125E3
+  LoRa.setSpreadingFactor(SpreadingFactor); // ranges from 6-12,default 7 see API docs
+  LoRa.setCodingRate4(CodingRate);          // Supported values are between 5 and 8, these correspond to coding rates of 4/5 and 4/8. The coding rate numerator is fixed at 4.
+  LoRa.setSyncWord(SyncWord);               // byte value to use as the sync word, defaults to 0x12
+  LoRa.setPreambleLength(PreambleLength);   // Supported values are between 6 and 65535.
+  LoRa.disableCrc();                        // Enable or disable CRC usage, by default a CRC is not used LoRa.disableCrc();
+  LoRa.setTxPower(TxPower);                 // TX power in dB, defaults to 17, Supported values are 2 to 20
 }
 
+void loop() {
+  if (LoRa.parsePacket()) {
+    String recv = "";
+    while (LoRa.available()) {
+      recv += (char)LoRa.read();
+    }
 
-
-void loop(){
-  
-    
-    if (LoRa.parsePacket()) {
-        String recv = "";
-        while (LoRa.available()) {
-            recv += (char)LoRa.read();
-        }
-        
-
-        Serial.println(recv);
-        if (client.connected()) {
-          client.publish("LoRa-Gateway/Code", String(recv).c_str(), retain);
-          String rs = String(LoRa.packetRssi());
-          client.publish("LoRa-Gateway/RSSI", rs.c_str(), retain);
-          client.endPublish();
-        }
-
+    Serial.println(recv);
+    if (client.connected()) {
+      client.publish("LoRa-Gateway/Code", String(recv).c_str(), retain);
+      String rs = String(LoRa.packetRssi());
+      client.publish("LoRa-Gateway/RSSI", rs.c_str(), retain);
+      client.endPublish();
+    }
   }
 
-    if (!client.connected()) 
-      {
-        reconnect();
-       }
-    client.loop();
-
+  if (!client.connected()) {
+    reconnect();
+  }
+  client.loop();
 }

--- a/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT/LoRa_Gateway_MQTT.ino
+++ b/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT/LoRa_Gateway_MQTT.ino
@@ -62,6 +62,20 @@ void reconnect() {
     // Attempt to connect
     if (client.connect(clientId.c_str(), mqtt_username, mqtt_password)) {
       Serial.println("MQTT connected");
+      
+      // Send auto-discovery message for sensor
+      client.publish(
+        "homeassistant/binary_sensor/mailbox/config",
+        "{\"name\":null,\"device_class\":\"door\",\"icon\":\"mdi:mailbox\",\"state_topic\":\"homeassistant/binary_sensor/mailbox/state\",\"unique_id\":\"mailbox_sensor\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        retain
+      );
+      
+      // Send auto-discovery message for signal
+      client.publish(
+        "homeassistant/sensor/mailbox/config",
+        "{\"name\":\"RSSI\",\"device_class\":\"signal_strength\",\"icon\":\"mdi:signal\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/state\",\"unique_id\":\"mailbox_signal\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        retain
+      );
     } else {
       Serial.print("MQTT failed, rc=");
       Serial.print(client.state());
@@ -121,9 +135,9 @@ void loop() {
 
     Serial.println(recv);
     if (client.connected()) {
-      client.publish("LoRa-Gateway/Code", String(recv).c_str(), retain);
+      client.publish("homeassistant/binary_sensor/mailbox/state", String(recv).c_str(), retain);
       String rs = String(LoRa.packetRssi());
-      client.publish("LoRa-Gateway/RSSI", rs.c_str(), retain);
+      client.publish("homeassistant/sensor/mailbox/state", rs.c_str(), retain);
       client.endPublish();
     }
   }

--- a/README.md
+++ b/README.md
@@ -182,14 +182,16 @@ const int mqtt_port = 1883;
 
 # Home Assistant Configuration
 
+If MQTT discovery has not been disabled, the device will appear automatically. Otherwise, you will need to manually create the sensor.
+
 ### Create a Sensor
 - File `loragateway.yaml`
 ```
 mqtt:
     sensor:
      - name: "LoRa_Code"
-       state_topic: "LoRa-Gateway/Code"
+       state_topic: "homeassistant/binary_sensor/mailbox/state"
 
      - name: "LoRa_RSSI"
-       state_topic: "LoRa-Gateway/RSSI"
+       state_topic: "homeassistant/sensor/mailbox/state"
 ```


### PR DESCRIPTION
This change sends the necessary discovery messages for Home Assistant to automatically discover the LoRa gateway. It will create a device named "Mailbox" that includes in the sensor and the signal strength, instead of them being completely separate entities.

I don't have the hardware on hand to test this, it's possible there may be bugs present. Additionally, I cleaned up the existing code in a separate commit so it's easier to see the non-style related change made.

Useful references:
https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
https://developers.home-assistant.io/docs/core/entity