### PR TITLE
MQTT Autodiscovery for Homeassistant + added Battery Percentage and more

### DIFF
--- a/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
+++ b/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
@@ -168,10 +168,15 @@ void parsePacket(String rawpkg){
 
   received_code=rawpkg.substring(0,i);
 
-  // "Converts" float to int - For cosmetic reasons. Modify, if desired
-  bat_val=rawpkg.substring(i+1);
-  intconv = bat_val.toFloat() + 0;
-  bat_val = String(intconv) + " %";
+  //Catch if Battery Percentage is not sent
+  if(rawpkg.length() <= i+1){
+    bat_val = "UNDEFINED";
+   } else {
+    // "Converts" float to int - For cosmetic reasons. Modify, if desired
+    bat_val=rawpkg.substring(i+1);
+    intconv = bat_val.toFloat() + 0;
+    bat_val = String(intconv);
+   }
   
   }
 

--- a/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
+++ b/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
@@ -27,6 +27,8 @@ bool retain = true;
 String NewMailCode = "REPLACE_WITH_NEW_MAIL_CODE"; // For Example "0xA2B2";
 String LowBatteryCode = "REPLACE_WITH_LOW_BATTERY_CODE"; // For Example "0xLBAT";
 
+// IMPORTANT: Set TransmitBattPercent to 1 in the Sensor Config!
+
 String bat_val = "";
 String received_code = "";
 

--- a/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
+++ b/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
@@ -24,6 +24,12 @@ const char *mqtt_server = "Your_mqtt/homeassistant server IP";
 const int mqtt_port = 1883;
 bool retain = true;
 
+String NewMailCode = "REPLACE_WITH_NEW_MAIL_CODE"; // For Example "0xA2B2";
+String LowBatteryCode = "REPLACE_WITH_LOW_BATTERY_CODE"; // For Example "0xLBAT";
+
+String bat_val = "";
+String received_code = "";
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 String recv;
@@ -54,6 +60,12 @@ void setup_wifi() {
 void reconnect() {
   while (!client.connected()) {
     Serial.print("Attempting MQTT connection...");
+    // Buffer needs to be increased to accomodate the config payloads
+    if(client.setBufferSize(380)){
+    Serial.println("Buffer Size increased to 380 byte"); 
+    }else{
+     Serial.println("Failed to allocate larger buffer");   
+     }
 
     // Create a random client ID
     String clientId = "LoRaGateway-";
@@ -62,18 +74,31 @@ void reconnect() {
     // Attempt to connect
     if (client.connect(clientId.c_str(), mqtt_username, mqtt_password)) {
       Serial.println("MQTT connected");
+
+     Serial.println("Buffersize: " + client.getBufferSize());   
+
       
       // Send auto-discovery message for sensor
       client.publish(
         "homeassistant/binary_sensor/mailbox/config",
-        "{\"name\":null,\"device_class\":\"door\",\"icon\":\"mdi:mailbox\",\"state_topic\":\"homeassistant/binary_sensor/mailbox/state\",\"unique_id\":\"mailbox_sensor\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        "{\"name\":null,\"device_class\":\"door\",\"icon\":\"mdi:mailbox\",\"state_topic\":\"homeassistant/binary_sensor/mailbox/state\",\"unique_id\":\"mailbox_sensor\",\"payload_on\":\"mail\",\"payload_off\":\"empty\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\",\"mdl\":\"MAILBOXguard+\",\"mf\":\"PricelessToolkit\"}}",
         retain
       );
       
       // Send auto-discovery message for signal
       client.publish(
-        "homeassistant/sensor/mailbox/config",
-        "{\"name\":\"RSSI\",\"device_class\":\"signal_strength\",\"icon\":\"mdi:signal\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/state\",\"unique_id\":\"mailbox_signal\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        "homeassistant/sensor/mailbox/rssi/config",
+        "{\"name\":\"RSSI\",\"device_class\":\"signal_strength\",\"icon\":\"mdi:signal\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/rssi\",\"unique_id\":\"mailbox_signal\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        retain
+      );
+       client.publish(
+        "homeassistant/sensor/mailbox/batt/config",
+        "{\"name\":\"Battery\",\"device_class\":\"battery\",\"icon\":\"mdi:battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/batt\",\"unique_id\":\"mailbox_batt\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        retain
+      );
+       client.publish(
+        "homeassistant/binary_sensor/mailbox/battlow/config",
+        "{\"name\":\"Battery State\",\"device_class\":\"battery\",\"icon\":\"mdi:battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/binary_sensor/mailbox/battlow\",\"unique_id\":\"mailbox_battlow\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
         retain
       );
     } else {
@@ -124,7 +149,29 @@ void setup() {
   LoRa.setPreambleLength(PreambleLength);   // Supported values are between 6 and 65535.
   LoRa.disableCrc();                        // Enable or disable CRC usage, by default a CRC is not used LoRa.disableCrc();
   LoRa.setTxPower(TxPower);                 // TX power in dB, defaults to 17, Supported values are 2 to 20
+ 
 }
+
+void parsePacket(String rawpkg){
+  int i = 0;
+  int intconv;
+
+  // Empty vals to be sure we have new data
+  bat_val = "";
+  received_code = "";
+  
+  while(rawpkg[i] != ',' && rawpkg[i] != '\0' ){
+    i++;
+  }
+
+  received_code=rawpkg.substring(0,i);
+
+  // "Converts" float to int - For cosmetic reasons. Modify, if desired
+  bat_val=rawpkg.substring(i+1);
+  intconv = bat_val.toFloat() + 0;
+  bat_val = String(intconv) + " %";
+  
+  }
 
 void loop() {
   if (LoRa.parsePacket()) {
@@ -135,9 +182,24 @@ void loop() {
 
     Serial.println(recv);
     if (client.connected()) {
-      client.publish("homeassistant/binary_sensor/mailbox/state", String(recv).c_str(), retain);
+      parsePacket(recv);
+      
+      if(received_code == NewMailCode){
+        client.publish("homeassistant/binary_sensor/mailbox/state", "mail", retain);
+       };
+       
+      if(received_code == LowBatteryCode){
+        client.publish("homeassistant/binary_sensor/mailbox/battlow", "ON", retain);
+       } else {
+        client.publish("homeassistant/binary_sensor/mailbox/battlow", "OFF", retain);
+       };
+
+       
+        
       String rs = String(LoRa.packetRssi());
-      client.publish("homeassistant/sensor/mailbox/state", rs.c_str(), retain);
+      client.publish("homeassistant/sensor/mailbox/rssi", rs.c_str(), retain);
+      client.publish("homeassistant/sensor/mailbox/batt", bat_val.c_str(), retain);
+
       client.endPublish();
     }
   }

--- a/Code/Arduino/Mailbox_Guard_Sensor/Mailbox_Guard_Sensor.ino
+++ b/Code/Arduino/Mailbox_Guard_Sensor/Mailbox_Guard_Sensor.ino
@@ -60,7 +60,7 @@ void loop() {
     delay(50);
     LoRa.beginPacket();
     if(TransmitBattPercent){
-      float perc = map(volts, 3.6, 4.2, 0, 100);
+      float perc = map(volts * 1000, 3600, 4200, 0, 100);
       LoRa.print(NewMailCode + "," + perc);
     } else{
       LoRa.print(NewMailCode);

--- a/Code/Arduino/Mailbox_Guard_Sensor/Mailbox_Guard_Sensor.ino
+++ b/Code/Arduino/Mailbox_Guard_Sensor/Mailbox_Guard_Sensor.ino
@@ -10,6 +10,7 @@
 
 #define SignalBandwidth 125E3
 #define SpreadingFactor 12
+#define TransmitBattPercent 0
 #define CodingRate 8
 #define SyncWord 0xF3
 #define PreambleLength 8
@@ -58,7 +59,12 @@ void loop() {
   if (loopcounter < 2){
     delay(50);
     LoRa.beginPacket();
-    LoRa.print(NewMailCode);
+    if(TransmitBattPercent){
+      float perc = map(volts, 3.6, 4.2, 0, 100);
+      LoRa.print(NewMailCode + "," + perc);
+    } else{
+      LoRa.print(NewMailCode);
+    }
     LoRa.endPacket();
     delay (10);
 

--- a/Code/Arduino/Mailbox_Guard_Sensor/Mailbox_Guard_Sensor.ino
+++ b/Code/Arduino/Mailbox_Guard_Sensor/Mailbox_Guard_Sensor.ino
@@ -10,7 +10,7 @@
 
 #define SignalBandwidth 125E3
 #define SpreadingFactor 12
-#define TransmitBattPercent 0
+#define TransmitBattPercent 0  // Enable if using MQTT Auto Discovery Gateway for Homeassistant
 #define CodingRate 8
 #define SyncWord 0xF3
 #define PreambleLength 8


### PR DESCRIPTION
Fixed the Autodiscovery for MQTT in HASS -> PubSubClient buffer was too small to fit the conf messages + some other misc problems.

- Added a switch in the Sensor firmware to send battery percentages Lora Packet:"NewMailCode,Batterypercentage"
- Gateway parses packet and sends status via mqtt
- Added Manufacturer + Model 

I kept it as a "door", just like the original contributer. To "empty" the mailbox, simply manually set the state to the string "empty" via mqtt payload through automation. 

Basically plug and play 😊

<img width="1150" alt="Screenshot 2023-09-05 at 23 27 37" src="https://github.com/PricelessToolkit/MailBoxGuard/assets/20824368/16fe84f4-c767-487f-86bd-19230a7313dd">
<img width="1181" alt="Screenshot 2023-09-05 at 23 27 23" src="https://github.com/PricelessToolkit/MailBoxGuard/assets/20824368/982a4d17-5885-4d8a-b101-c6c985bb0469">

