### PR TITLE
Add unit of measurement to rssi and battery percentage

### DIFF
--- a/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
+++ b/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
@@ -90,15 +90,15 @@ void reconnect() {
       // Send auto-discovery message for signal
       client.publish(
         "homeassistant/sensor/mailbox/rssi/config",
-        "{\"name\":\"RSSI\",\"device_class\":\"signal_strength\",\"icon\":\"mdi:signal\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/rssi\",\"unique_id\":\"mailbox_signal\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        "{\"name\":\"RSSI\",\"unit_of_measurement\":\"dBm\",\"device_class\":\"signal_strength\",\"icon\":\"mdi:signal\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/rssi\",\"unique_id\":\"mailbox_signal\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
         retain
       );
-       client.publish(
+      client.publish(
         "homeassistant/sensor/mailbox/batt/config",
-        "{\"name\":\"Battery\",\"device_class\":\"battery\",\"icon\":\"mdi:battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/batt\",\"unique_id\":\"mailbox_batt\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        "{\"name\":\"Battery\",\"unit_of_measurement\":\"%\",\"device_class\":\"battery\",\"icon\":\"mdi:battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/batt\",\"unique_id\":\"mailbox_batt\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
         retain
       );
-       client.publish(
+      client.publish(
         "homeassistant/binary_sensor/mailbox/battlow/config",
         "{\"name\":\"Battery State\",\"device_class\":\"battery\",\"icon\":\"mdi:battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/binary_sensor/mailbox/battlow\",\"unique_id\":\"mailbox_battlow\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
         retain


### PR DESCRIPTION
Without the unit of measurement being published for entities of device class battery and signal strength, Home Assistant will throw the below error any time the state is updated. 

```
Logger: homeassistant.components.sensor
Source: components/sensor/__init__.py:661
Integration: Sensor (documentation, issues)

Entity sensor.mailbox_rssi (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement 'None' which is not a valid unit for the device class ('signal_strength') it is using; expected one of ['dBm', 'dB']

Entity sensor.mailbox_battery (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement 'None' which is not a valid unit for the device class ('battery') it is using; expected one of ['%']
```

This pull request adds the relevant units of measurement, resolving the error. 