### PR TITLE
Reworking Communication and Code

### DIFF
--- a/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/secrets.h
+++ b/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/secrets.h
@@ -1,0 +1,6 @@
+#define WIFI_SSID "your_wifi_ssid"
+#define WIFI_PASSWORD "your_wifi_passwd"
+#define MQTT_USERNAME "your_mqtt_user"
+#define MQTT_PASSWORD "your_mqtt_passwd"
+#define MQTT_SERVER "your_mqtt_broker_address"
+#define MQTT_PORT 1883

--- a/Code/Arduino/Mailbox_Guard_Sensor/Mailbox_Guard_Sensor_MQTT_Auto_Discovery/Mailbox_Guard_Sensor_MQTT_Auto_Discovery.ino
+++ b/Code/Arduino/Mailbox_Guard_Sensor/Mailbox_Guard_Sensor_MQTT_Auto_Discovery/Mailbox_Guard_Sensor_MQTT_Auto_Discovery.ino
@@ -5,84 +5,63 @@
 #include <LoRa.h>
 #include <avr/sleep.h>
 
+///////////////////////////////// CHANGE THIS /////////////////////////////////
 
-//////////////////////////////////// CONFIG /////////////////////////////////////////////
+#define SIGNAL_BANDWITH 125E3
+#define SPREADING_FACTOR 7
+#define TRANSMIT_BATTERY_VOLTAGE 1
+#define CODING_RATE 5
+#define SYNC_WORD 0xF3
+#define PREAMBLE_LENGTH 8
+#define TX_POWER 5
+#define BAND 433E6  // 433E6 / 868E6 / 915E6
+#define NEW_MAIL_CODE "NEWMAIL"
 
-#define SignalBandwidth 125E3
-#define SpreadingFactor 12
-#define TransmitBattPercent 1
-#define CodingRate 8
-#define SyncWord 0xF3
-#define PreambleLength 8
-#define TxPower 20
-#define BAND 868E6     // frequency in Hz (ASIA 433E6, EU 868E6, US 915E6)
-String NewMailCode = "REPLACE_WITH_NEW_MAIL_CODE"; // For Example "0xA2B2";
-String LowBatteryCode = "REPLACE_WITH_LOW_BATTERY_CODE"; // For Example "0xLBAT";
-
-/////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 
 int loopcounter = 0;
 
 void setup() {
   pinMode(3, OUTPUT);
   digitalWrite(3, HIGH);
-  Serial.begin(9600);   //Pin6 RX Pin7 TX
+  Serial.begin(9600);
   analogReference(VDD);
-  delay (5);
-
+  delay(5);
 
   if (!LoRa.begin(BAND)) {
     Serial.println("LoRaError");
-    while (1);
+    while (1) {}
   }
 
-  LoRa.setSignalBandwidth(SignalBandwidth);         // signal bandwidth in Hz, defaults to 125E3
-  LoRa.setSpreadingFactor(SpreadingFactor);                 // ranges from 6-12,default 7 see API docs
-  LoRa.setCodingRate4(CodingRate);        // Supported values are between 5 and 8, these correspond to coding rates of 4/5 and 4/8. The coding rate numerator is fixed at 4.
-  LoRa.setSyncWord(SyncWord);                     // byte value to use as the sync word, defaults to 0x12
-  LoRa.setPreambleLength(PreambleLength);       //Supported values are between 6 and 65535.
-  LoRa.disableCrc();                          // Enable or disable CRC usage, by default a CRC is not used LoRa.disableCrc();
-  LoRa.setTxPower(TxPower);                // TX power in dB, defaults to 17, Supported values are 2 to 20
-
-
-
-  
+  // LoRa.setSignalBandwidth(SIGNAL_BANDWITH);  // signal bandwidth in Hz, defaults to 125E3
+  // LoRa.setSpreadingFactor(SPREADING_FACTOR);  // supports values 6 - 12, defaults to 7
+  // LoRa.setCodingRate4(CODING_RATE);  // supported values 5 - 8, defaults to 5
+  LoRa.setSyncWord(SYNC_WORD);  // byte value to use as the sync word, defaults to 0x12
+  // LoRa.setPreambleLength(PREAMBLE_LENGTH);  // supports values 6 - 65535, defaults to 8
+  // LoRa.disableCrc();   // enable or disable CRC usage, defaults to disabled
+  // LoRa.setTxPower(TX_POWER);  // TX power in dB, supports values 2 - 20, defaults to 17
 }
 
 
 void loop() {
-	
-  float volts = analogReadEnh(PIN_PB4, 12)*(1.1/4096)*(30+10)/10;
-  Serial.println(volts);
-  
-
-  if (loopcounter < 2){
+  if (loopcounter < 2) {
     delay(50);
     LoRa.beginPacket();
-    if(TransmitBattPercent){
-      float perc = map(volts * 1000, 3360, 4200, 0, 100);
-      perc = constrain(perc, 0, 100); // Constrain the value between 0 and 100
-      LoRa.print(NewMailCode + "," + perc);
-    } else{
-      LoRa.print(NewMailCode);
-    }
+#if TRANSMIT_BATTERY_VOLTAGE
+    float volts = analogReadEnh(PIN_PB4, 12) * (1.1 / 4096) * (30 + 10) / 10;
+    Serial.println(volts);
+    LoRa.print("{\"message\":\"" + String(NEW_MAIL_CODE) + "\",\"bat_voltage\":" + volts + "}");
+#else
+    LoRa.print("{\"message\":\"" + String(NEW_MAIL_CODE) + "\"}");
+#endif
     LoRa.endPacket();
-    delay (10);
-
-   }
-
-  if (volts < 3.36 and loopcounter == 1 ){   // Don't change "3.36" !!
-    LoRa.beginPacket();
-    LoRa.print(LowBatteryCode);
-    LoRa.endPacket();
-    delay(50);
+    delay(10);
   }
 
-  if(loopcounter > 2){
-    //LoRa.end();  // Stop the LoRa library.
+  if (loopcounter > 2) {
     LoRa.sleep();  // Put the radio in sleep mode
-    digitalWrite(3, LOW); // Sets the Latch pin 3 LOW For power cut off
-    
+    digitalWrite(3, LOW);  // Sets the Latch pin 3 LOW For power cut off
+
     /* Set sleep mode to PWR_DOWN */
     // There are five different sleep modes in order of power saving:
     // SLEEP_MODE_IDLE - the lowest power saving mode
@@ -90,12 +69,12 @@ void loop() {
     // SLEEP_MODE_PWR_SAVE
     // SLEEP_MODE_STANDBY
     // SLEEP_MODE_PWR_DOWN - the highest power saving mode
-    
+
     set_sleep_mode(SLEEP_MODE_PWR_DOWN);
     sleep_enable();
     sleep_mode();  // Now enter sleep mode.
   }
 
-  loopcounter ++;
+  loopcounter++;
   delay(10);
 }


### PR DESCRIPTION
LoRa Gateway
- add secrets.h to store wifi and mqtt credentials
- set lora setting to defaults (see Mailbox Sensor)
- moved most const something variables to #define
- created a struct to store lora message contents
- parse JSON string coming via lora (see Mailbox Sensor)
- removed "magic numbers" from code where applicable and made them configurable
- removed battery percentage mqtt topic (does not make sense)
- removed battery low alert (also does not make sense)
- added battery voltage topic
- ran cpplint to fix appearance (except some line length issues) and fixed some naming convention issues

Mailbox Sensor
- set lora settings to defaults so there is no need for reconfiguration of the lora rf chip on every wake-up
- removed battery level calculation and low battery lora message as the sensor does not know what kind of power supply is connected and hence should not decide if the battery is full or empty
- added battery voltage to lora message (now HomeAssistant can decide on its own if that is a high or low voltage)
- changed message format to JSON for easier parsing/extension
- moved most const something variables to #define
- run cpplint to fix appearance (except some line length issues)