### PR TITLE
Fix retain after restart of Home Assistant

### DIFF
--- a/Code/Home_Assistant/MQTT/automation_MQTT_Auto_Discovery.yaml
+++ b/Code/Home_Assistant/MQTT/automation_MQTT_Auto_Discovery.yaml
@@ -13,3 +13,4 @@ action:
     data:
       topic: homeassistant/binary_sensor/mailbox/state
       payload: empty
+      retain: true


### PR DESCRIPTION
Just noticed that if my mailbox is closed (payload "empty") and i restart Home Assistant, the MQTT Broker apparently resends retained message again, which was "open".

![image](https://github.com/PricelessToolkit/MailBoxGuard/assets/2077668/65d4494c-368e-4103-ab19-2438f9a0e11d)

Quick fix is to include `retain: true` into your automation, but maybe there is a way to not retain messages at all, so that after restart the status would not change. I'm thinking of trying to remove the retain flag in the Gateway's client.publish method, because now after restart it's resent to HA, which is admittedly much better than before:

![image](https://github.com/PricelessToolkit/MailBoxGuard/assets/2077668/04bcc967-f4d7-4dad-b08f-e1c717f9ed52)
