### PR TITLE
Fix retain and Home Assistant battery icon

### DIFF
--- a/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
+++ b/Code/Arduino/LoRa_Gateway/LoRa_Gateway_MQTT_Auto_Discovery/LoRa_Gateway_MQTT_Auto_Discovery.ino
@@ -95,12 +95,12 @@ void reconnect() {
       );
       client.publish(
         "homeassistant/sensor/mailbox/batt/config",
-        "{\"name\":\"Battery\",\"unit_of_measurement\":\"%\",\"device_class\":\"battery\",\"icon\":\"mdi:battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/batt\",\"unique_id\":\"mailbox_batt\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        "{\"name\":\"Battery\",\"unit_of_measurement\":\"%\",\"device_class\":\"battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/sensor/mailbox/batt\",\"unique_id\":\"mailbox_batt\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
         retain
       );
       client.publish(
         "homeassistant/binary_sensor/mailbox/battlow/config",
-        "{\"name\":\"Battery State\",\"device_class\":\"battery\",\"icon\":\"mdi:battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/binary_sensor/mailbox/battlow\",\"unique_id\":\"mailbox_battlow\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
+        "{\"name\":\"Battery State\",\"device_class\":\"battery\",\"entity_category\":\"diagnostic\",\"state_topic\":\"homeassistant/binary_sensor/mailbox/battlow\",\"unique_id\":\"mailbox_battlow\",\"device\":{\"identifiers\":[\"mailbox\"],\"name\":\"Mailbox\"}}",
         retain
       );
     } else {

--- a/Code/Home_Assistant/MQTT/automation_MQTT_Auto_Discovery.yaml
+++ b/Code/Home_Assistant/MQTT/automation_MQTT_Auto_Discovery.yaml
@@ -13,3 +13,4 @@ action:
     data:
       topic: homeassistant/binary_sensor/mailbox/state
       payload: empty
+      retain: true


### PR DESCRIPTION
### Issue `#1`:

Just noticed that if my mailbox is closed (payload "empty") and i restart Home Assistant, the MQTT Broker apparently resends retained message again, which was "open".

![image](https://github.com/PricelessToolkit/MailBoxGuard/assets/2077668/65d4494c-368e-4103-ab19-2438f9a0e11d)

Quick fix is to include `retain: true` into your automation, but maybe there is a way to not retain messages at all, so that after restart the status would not change. I'm thinking of trying to remove the retain flag in the Gateway's client.publish method, because now after restart it's resent to HA, which is admittedly much better than before:

![image](https://github.com/PricelessToolkit/MailBoxGuard/assets/2077668/04bcc967-f4d7-4dad-b08f-e1c717f9ed52)

### Issue `#2`:

So i got a list of batteries to control with default entities card. Noticed mailbox with 77% showed 100% icon. 
![image](https://github.com/PricelessToolkit/MailBoxGuard/assets/2077668/5e5fffa1-9641-45ae-8ef7-dc8bcbbdccd9)

Compared with other sensor's autodiscovery payload and removed the icon. That fixes auto-icon from HA.